### PR TITLE
Fixed typo in method signature

### DIFF
--- a/Classes/PopupController.swift
+++ b/Classes/PopupController.swift
@@ -157,7 +157,7 @@ public extension PopupController {
         return self
     }
     
-    public func didCloseHanlder(handler: (PopupController) -> Void) -> PopupController {
+    public func didCloseHandler(handler: (PopupController) -> Void) -> PopupController {
         self.closedHandler = handler
         return self
     }

--- a/Example/PopupController/ViewController.swift
+++ b/Example/PopupController/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
             .didShowHandler { popup in
                 print("showed popup!")
             }
-            .didCloseHanlder { _ in
+            .didCloseHandler { _ in
                 print("closed popup!")
             }
             .show(DemoPopupViewController2.instance())
@@ -55,7 +55,7 @@ class ViewController: UIViewController {
             .didShowHandler { popup in
                 print("showed popup!")
             }
-            .didCloseHanlder { popup in
+            .didCloseHandler { popup in
                 print("closed popup!")
         }
         


### PR DESCRIPTION
Fixed typo in method signature from ```didCloseHanlder ``` to ```didCloseHandler```